### PR TITLE
v0.6.6: Restructure commands - nest utility operations under 'util' 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4225,7 +4225,7 @@ dependencies = [
 
 [[package]]
 name = "sai3-bench"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sai3-bench"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 build   = "build.rs"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sai3-bench: Multi-Protocol I/O Benchmarking Suite
 
-[![Version](https://img.shields.io/badge/version-0.6.5-blue.svg)](https://github.com/russfellows/sai3-bench/releases)
+[![Version](https://img.shields.io/badge/version-0.6.6-blue.svg)](https://github.com/russfellows/sai3-bench/releases)
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](https://github.com/russfellows/sai3-bench)
 [![Tests](https://img.shields.io/badge/tests-35%20passing-success.svg)](https://github.com/russfellows/sai3-bench)
 [![License](https://img.shields.io/badge/license-GPL--3.0-blue.svg)](LICENSE)
@@ -8,150 +8,7 @@
 
 A storage performance testing tool that supports multiple backends through a unified interface. Built on the [s3dlio Rust library](https://github.com/russfellows/s3dlio) (v0.9.6) for multi-protocol support.
 
-> **Latest (v0.6.5)**: Added config validation with `--dry-run` flag, comprehensive data generation documentation, and improved fill pattern recommendations. All configs can now be validated before execution with detailed test summaries. See [CHANGELOG](docs/CHANGELOG.md) for details.
-
-> **Previous (v0.6.4)**: Enhanced output with automatic results directories and HDR histogram merging for distributed workloads. All test results are now captured in timestamped directories with mathematically accurate consolidated metrics.
-
-## 🚀 What Makes sai3-bench Unique?
-
-1. **Universal Storage Testing**: Unified interface across 5 storage protocols (file://, direct://, s3://, az://, gs://)
-2. **RangeEngine Performance**: Automatic 30-50% throughput boost for large files (≥4MB) via concurrent byte-range requests
-3. **Configurable Data Patterns**: Deduplication and compression testing with configurable data characteristics
-4. **Workload Replay**: Timing-faithful replay with flexible remapping capabilities (1→1, 1→N, N→1, regex)
-5. **Statistical Size Distributions**: Lognormal, uniform, and fixed distributions for realistic object size modeling
-6. **Production-Grade Metrics**: Microsecond-precision HDR histograms with size-bucketed analysis
-7. **Machine-Readable Output**: TSV export (sorted by bucket_idx) for automated analysis and CI/CD integration
-8. **Distributed Architecture**: gRPC-based agent/controller system for large-scale load generation
-9. **Storage Efficiency Testing**: Built-in support for testing deduplication engines and compression algorithms
-
-## 🎯 Supported Storage Backends
-
-- **File System** (`file://`) - Local filesystem testing with standard POSIX operations
-- **Direct I/O** (`direct://`) - High-performance direct I/O for maximum throughput
-- **Amazon S3** (`s3://`) - S3 and S3-compatible storage (MinIO, etc.) with optional RangeEngine
-- **Azure Blob** (`az://`) - Microsoft Azure Blob Storage with optional RangeEngine
-- **Google Cloud Storage** (`gs://` or `gcs://`) - Google Cloud Storage with optional RangeEngine
-
-**RangeEngine Configuration** (v0.6.3): RangeEngine is **disabled by default** in s3dlio v0.9.6 for optimal performance on typical workloads. For large-file workloads (≥64 MiB), explicitly enable it in your config:
-```yaml
-range_engine:
-  enabled: true
-  min_split_size: 16777216  # 16 MiB threshold
-  chunk_size: 67108864      # 64 MiB chunks
-  max_concurrent_ranges: 16
-```
-**When to enable**: Only for workloads with large files where network bandwidth is NOT the bottleneck (10+ Gbps networks). See [CHANGELOG](docs/CHANGELOG.md#063) for performance analysis.
-
-## 📦 Architecture & Binaries
-
-- **`sai3-bench`** - Single-node CLI for immediate testing across all backends
-- **`sai3bench-agent`** - Distributed gRPC agent for multi-node load generation (now supports all backends!)
-- **`sai3bench-ctl`** - Controller for coordinating distributed agents
-- **`sai3bench-run`** - Dedicated workload runner (legacy, being integrated)
-
-## 📖 Documentation
-- **[Usage Guide](docs/USAGE.md)** - Getting started with sai3-bench
-- **[Distributed Testing Guide](docs/DISTRIBUTED_TESTING_GUIDE.md)** - Multi-host load generation and testing
-- **[Cloud Storage Setup](docs/CLOUD_STORAGE_SETUP.md)** - S3, Azure, and GCS authentication guides
-- **[Data Generation Guide](docs/DATA_GENERATION.md)** - Fill patterns, deduplication, and compression testing
-- **[Changelog](docs/CHANGELOG.md)** - Complete version history and release notes
-- **[Config Syntax](docs/CONFIG_SYNTAX.md)** - YAML configuration reference
-- **[Config Examples](tests/configs/README.md)** - Complete guide to test configurations
-
-## 🏆 sai3-bench Capabilities Overview
-
-| Capability | Implementation | Use Cases |
-|------------|----------------|----------|
-| **Storage Backends** | 5 protocols via unified API | Cross-cloud migration, protocol comparison |
-| **RangeEngine** | Automatic for files ≥4MB | 30-50% faster downloads on Azure/GCS/S3 |
-| **Size Distributions** | Lognormal, uniform, fixed | Realistic workload modeling |
-| **Data Characteristics** | Configurable dedup/compression | Storage efficiency testing |
-| **Workload Replay** | Microsecond-precision timing | Production load analysis |
-| **Advanced Remapping** | 1:1, 1→N, N→1, N↔N patterns | Complex migration scenarios |
-| **Concurrency Control** | Global + per-operation | Fine-grained performance tuning |
-| **Output Format** | 13-column TSV (bucket-sorted) | Automated analysis, CI/CD |
-| **Memory Efficiency** | Constant ~1.5MB (streaming) | Large-scale workload replay |
-| **Distributed Testing** | gRPC agent/controller | Multi-node load generation |
-
-## 🔬 Workload Replay Capabilities
-
-Most benchmarking tools generate synthetic workloads that may not represent real-world usage patterns. sai3-bench's workload replay capability addresses this by allowing you to record and replay actual production workloads:
-
-**The Problem**: Most tools create artificial load patterns that don't match production behavior:
-- Fixed operation ratios that never vary
-- Regular timing patterns unlike bursty real workloads  
-- Simple object access patterns vs. complex real-world sequences
-
-**sai3-bench's Solution**: Record actual production workloads and replay them with microsecond fidelity:
-
-```bash
-# Step 1: Capture your real production workload (transparent logging)
-sai3-bench --op-log /tmp/production.tsv.zst run --config production.yaml
-
-# Step 2: Analyze the captured workload patterns
-zstd -d /tmp/production.tsv.zst -c | head -10
-# Shows: operation_type, object_path, timing, sizes, access_patterns
-
-# Step 3: Replay against test environment with exact timing
-sai3-bench replay --op-log /tmp/production.tsv.zst --target "az://test-storage/"
-
-# Step 4: Migration testing - replay S3 workload against other backends
-sai3-bench replay --op-log /tmp/s3-prod.tsv.zst --target "gs://migration-test/"
-
-# Step 5: Load testing - replay at higher speeds
-sai3-bench replay --op-log /tmp/prod.tsv.zst --speed 5.0  # 5x faster
-```
-
-**Real-World Applications**:
-- **Pre-Migration Validation**: Test new storage backend with exact production load
-- **Performance Regression Testing**: Detect changes using historical workload patterns
-- **Capacity Planning**: Model peak load behavior with recorded traffic spikes
-- **Cross-Cloud Comparison**: Run identical workloads across AWS, Azure, GCS
-- **Cost Analysis**: Measure actual vs. synthetic workload costs
-
-## 💾 Storage Efficiency Testing
-
-Many benchmarking tools generate random data, which provides limited insight into storage system efficiency. sai3-bench includes controlled data generation for more realistic storage testing:
-
-**Why This Matters**: Modern storage systems use deduplication and compression:
-- **Enterprise Storage**: NetApp, EMC, Dell systems claim 2-10x space savings
-- **Cloud Storage**: AWS, Azure, GCS offer transparent compression
-- **Filesystems**: ZFS, Btrfs, NTFS provide built-in compression
-- **Backup Systems**: Veeam, CommVault depend on dedup effectiveness
-
-**Testing Strategy**:
-```yaml
-# Simulate typical enterprise data mix
-prepare:
-  # Highly dedupable data (VM templates, OS images)
-  - path: "templates/"
-    num_objects: 100
-    size_distribution: {type: fixed, size: 10485760}  # 10MB each
-    dedup_factor: 20     # 95% duplicate blocks
-    compress_factor: 2   # 2:1 compression ratio
-  
-  # Document storage (moderate compression)
-  - path: "documents/"
-    num_objects: 5000
-    size_distribution: {type: lognormal, mean: 524288, std_dev: 262144}
-    dedup_factor: 3      # 67% unique blocks
-    compress_factor: 4   # 4:1 compression ratio
-  
-  # Media files (minimal compression)
-  - path: "media/"
-    num_objects: 500
-    size_distribution: {type: uniform, min: 5242880, max: 52428800}
-    dedup_factor: 1      # 100% unique (no dedup)
-    compress_factor: 1   # Uncompressible (encrypted/compressed)
-```
-
-**Validation Scenarios**:
-- **Storage Vendor Claims**: Verify "up to 10:1 dedup ratio" promises
-- **Migration Planning**: Predict space requirements after dedup/compression
-- **Tier Optimization**: Model hot vs. cold data characteristics
-- **Cost Modeling**: Calculate true storage costs with efficiency features
-
-A storage performance testing tool that supports multiple backends through a unified interface. Built on the [s3dlio Rust library](https://github.com/russfellows/s3dlio) for multi-protocol support.
+> **Latest (v0.6.6)**: Restructured commands to emphasize core workload execution (run/replay). Utility operations (health/list/stat/get/put/delete) now nested under `util` subcommand. **Breaking change**: Use `sai3-bench util health` instead of `sai3-bench health`. See [CHANGELOG](docs/CHANGELOG.md) for details.
 
 ## 🚀 What Makes sai3-bench Unique?
 
@@ -162,7 +19,7 @@ A storage performance testing tool that supports multiple backends through a uni
 5. **Production-Grade Metrics**: Microsecond-precision HDR histograms with size-bucketed analysis
 6. **Machine-Readable Output**: TSV export for automated analysis and CI/CD integration
 7. **Distributed Architecture**: gRPC-based agent/controller system for large-scale load generation
-8. **Storage Efficiency Testing**: Built-in support for testing deduplication engines and compression algorithms
+8. **Config Validation**: Parse and verify YAML configs before execution with `--dry-run`
 
 ## 🎯 Supported Storage Backends
 
@@ -172,394 +29,85 @@ A storage performance testing tool that supports multiple backends through a uni
 - **Azure Blob** (`az://`) - Microsoft Azure Blob Storage with full authentication support
 - **Google Cloud Storage** (`gs://` or `gcs://`) - Google Cloud Storage with native GCS API support
 
+All backends support RangeEngine for large file downloads (disabled by default for optimal performance). Enable in config for files ≥16 MiB on high-bandwidth networks.
+
 ## 📦 Architecture & Binaries
 
 - **`sai3-bench`** - Single-node CLI for immediate testing across all backends
 - **`sai3bench-agent`** - Distributed gRPC agent for multi-node load generation  
 - **`sai3bench-ctl`** - Controller for coordinating distributed agents
-- **`sai3bench-run`** - Dedicated workload runner (legacy, being integrated)
 
 ## 📖 Documentation
 - **[Usage Guide](docs/USAGE.md)** - Getting started with sai3-bench
 - **[Distributed Testing Guide](docs/DISTRIBUTED_TESTING_GUIDE.md)** - Multi-host load generation and testing
 - **[Cloud Storage Setup](docs/CLOUD_STORAGE_SETUP.md)** - S3, Azure, and GCS authentication guides
 - **[Data Generation Guide](docs/DATA_GENERATION.md)** - Fill patterns, deduplication, and compression testing
-- **[Changelog](docs/CHANGELOG.md)** - Complete version history and release notes
 - **[Config Syntax](docs/CONFIG_SYNTAX.md)** - YAML configuration reference
+- **[Config Examples](tests/configs/README.md)** - Complete guide to test configurations
+- **[Changelog](docs/CHANGELOG.md)** - Complete version history and release notes
 
-## 🎊 Latest Release (v0.6.0) - Distributed Multi-Host Workload Execution
-
-### 🌐 Distributed Benchmarking
-Run coordinated workloads across multiple agent nodes with automatic shared/local storage detection.
-
-```bash
-# Start agents on multiple hosts
-sai3bench-agent --listen 0.0.0.0:7761  # On host 1
-sai3bench-agent --listen 0.0.0.0:7761  # On host 2
-sai3bench-agent --listen 0.0.0.0:7761  # On host 3
-
-# Run distributed workload from controller
-sai3bench-ctl --insecure --agents host1:7761,host2:7761,host3:7761 \
-    run --config production-workload.yaml --start-delay 2
-
-# Output shows per-agent and aggregate results
-=== Distributed Results ===
-Total agents: 3
-
---- Agent: agent-1 ---
-  Wall time: 10.02s
-  Total ops: 102156 (10195.21 ops/s)
-  Total bytes: 85.23 MB (8.51 MiB/s)
-  GET: 71509 ops, 59.66 MB, mean: 225µs, p95: 315µs
-  PUT: 30647 ops, 25.57 MB, mean: 109µs, p95: 155µs
-
---- Agent: agent-2 ---
-  Wall time: 10.01s
-  Total ops: 101834 (10173.13 ops/s)
-  Total bytes: 84.98 MB (8.49 MiB/s)
-  GET: 71324 ops, 59.48 MB, mean: 228µs, p95: 318µs
-  PUT: 30510 ops, 25.50 MB, mean: 111µs, p95: 157µs
-
---- Agent: agent-3 ---
-  Wall time: 10.03s
-  Total ops: 102089 (10181.45 ops/s)
-  Total bytes: 85.18 MB (8.49 MiB/s)
-  GET: 71463 ops, 59.62 MB, mean: 226µs, p95: 316µs
-  PUT: 30626 ops, 25.56 MB, mean: 110µs, p95: 156µs
-
---- Aggregate ---
-  Total ops: 306079
-  Total bytes: 255.39 MB
-  Combined throughput: 30549.79 ops/s
-```
-
-**Key Features**:
-- **Coordinated Start**: All agents begin workload simultaneously with nanosecond-precision synchronization
-- **Per-Agent Path Isolation**: Each agent operates in isolated subdirectory (e.g., `agent-1/`, `agent-2/`)
-- **Smart Storage Detection**: Automatic handling based on URI scheme:
-  - **Shared storage** (S3/GCS/Azure): All agents use same prepared dataset
-  - **Local storage** (file://): Each agent prepares own isolated dataset
-- **Result Aggregation**: Per-agent statistics plus combined throughput metrics
-- **Flexible Configuration**: Override agent IDs, path templates, and storage mode
-
-**Controller Flags**:
-```bash
---config <file>           # YAML workload configuration
---path-template <template> # Agent path prefix (default: "agent-{id}/")
---agent-ids <list>        # Custom agent identifiers
---start-delay <seconds>   # Coordinated start delay (default: 2)
---shared-prepare          # Override auto-detected storage mode
-```
-
-**Use Cases**:
-- **Large-Scale Load Testing**: Generate 100k+ ops/s across multiple nodes
-- **Distributed System Validation**: Test storage backend under multi-client load
-- **Cloud Migration Testing**: Parallel workload execution from multiple regions
-- **Performance Baselines**: Measure aggregate throughput across infrastructure
-
-### 🧪 Storage Efficiency Testing (v0.5.4)
-Deduplication & compression testing with controlled data patterns.
-
-```yaml
-prepare:
-  - path: "dedupe-test/"
-    num_objects: 1000
-    size_distribution:
-      type: lognormal
-      mean: 1048576
-      std_dev: 524288
-    dedup_factor: 5       # 20% unique blocks (80% duplicate)
-    compress_factor: 3    # 67% zeros (3:1 compression ratio)
-
-workload:
-  - op: put
-    path: "mixed-data/"
-    weight: 100
-    size_distribution:
-      type: uniform
-      min: 1024
-      max: 10485760
-    dedup_factor: 1       # 100% unique (no deduplication)
-    compress_factor: 1    # Random data (uncompressible)
-```
-
-**Parameters Explained**:
-- `dedup_factor`: Controls block-level duplication patterns
-  - `1` = All unique blocks (no deduplication opportunity)
-  - `2` = 50% unique blocks (50% dedup ratio)
-  - `5` = 20% unique blocks (80% dedup ratio)
-  - `10` = 10% unique blocks (90% dedup ratio)
-  - Higher values = more duplication opportunities
-
-- `compress_factor`: Controls data compressibility
-  - `1` = Random data (uncompressible, realistic for encrypted/media files)
-  - `2` = 50% zeros (2:1 compression ratio, typical for logs)
-  - `3` = 67% zeros (3:1 compression ratio, common for documents)
-  - `5` = 80% zeros (5:1 compression ratio, sparse databases)
-  - Higher values = more compressible content
-
-**Use Cases**:
-- **Deduplication Engine Testing**: Validate NetApp, EMC, Dell, and other enterprise dedup systems
-- **Compression Algorithm Validation**: Test ZFS, Btrfs, NTFS, and cloud storage compression
-- **Storage Efficiency Analysis**: Measure real-world space savings with realistic data patterns
-- **Capacity Planning**: Model storage requirements with various data characteristics
-- **Cloud Cost Optimization**: Test compression effectiveness before large migrations
-- **Backup System Validation**: Verify dedup ratios match vendor claims
-
-### 📐 Realistic Object Size Distributions
-**Research-Based Modeling**: Object storage workloads naturally follow statistical distributions.
-
-1. **Fixed Size** (backward compatible):
-   ```yaml
-   - op: put
-     path: "data/"
-     object_size: 1048576  # Exactly 1 MB
-   ```
-
-2. **Uniform Distribution** (evenly distributed):
-   ```yaml
-   - op: put
-     path: "data/"
-     size_distribution:
-       type: uniform
-       min: 1024        # 1 KB
-       max: 10485760    # 10 MB
-   ```
-
-3. **Lognormal Distribution** (realistic - recommended):
-   ```yaml
-   - op: put
-     path: "data/"
-     size_distribution:
-       type: lognormal
-       mean: 1048576      # Mean size: 1 MB
-       std_dev: 524288    # Std deviation: 512 KB
-       min: 1024          # Floor
-       max: 10485760      # Ceiling (10 MB)
-   ```
-
-**Why lognormal?** Research shows object storage workloads naturally follow lognormal distributions - users create many small files (configs, thumbnails, metadata) and few large files (videos, backups). This is far more realistic than simple random distributions.
-
-### ⚙️ Per-Operation Concurrency
-Fine-grained control over worker pools per operation type:
-
-```yaml
-concurrency: 32  # Global default
-
-workload:
-  - op: get
-    path: "data/*"
-    weight: 70
-    concurrency: 64  # Override: More GET workers
-  
-  - op: put
-    path: "data/"
-    object_size: 1048576
-    weight: 30
-    concurrency: 8   # Override: Fewer PUT workers
-```
-
-**Use case**: Simulate real-world scenarios where reads far outnumber writes, or model slow backend write performance.
-
-### 🎯 Prepare Profiles
-Documented patterns for realistic test data preparation:
-
-```yaml
-prepare:
-  ensure_objects:
-    # Small objects (thumbnails, metadata) - lognormal
-    - base_uri: "s3://bucket/small/"
-      count: 10000
-      size_distribution:
-        type: lognormal
-        mean: 4096
-        std_dev: 2048
-        min: 1024
-        max: 65536
-      fill: random
-    
-    # Medium objects (documents, images) - lognormal
-    - base_uri: "s3://bucket/medium/"
-      count: 1000
-      size_distribution:
-        type: lognormal
-        mean: 1048576
-        std_dev: 524288
-        min: 65536
-        max: 10485760
-      fill: zero
-    
-    # Large objects (videos, backups) - uniform
-    - base_uri: "s3://bucket/large/"
-      count: 100
-      size_distribution:
-        type: uniform
-        min: 10485760
-        max: 104857600
-      fill: zero
-```
-
-### 🔄 Advanced Remapping Examples
-**N↔N (Many-to-Many) Remapping** with regex:
-
-```yaml
-# Map 3 source buckets → 2 destination buckets
-remap:
-  # Source bucket 1 & 2 → Destination bucket A
-  - pattern: "s3://source-1/(.+)"
-    replacement: "s3://dest-a/$1"
-  - pattern: "s3://source-2/(.+)"
-    replacement: "s3://dest-a/$1"
-  
-  # Source bucket 3 → Destination bucket B
-  - pattern: "s3://source-3/(.+)"
-    replacement: "s3://dest-b/$1"
-```
-
-### 🏆 Competitive Advantage vs Warp
-
-| Feature | Warp | sai3-bench v0.6.0 |
-|---------|------|-----------------|
-| **Distributed execution** | No | **gRPC-based multi-host** coordination |
-| **Storage detection** | N/A | **Auto-detect shared vs local** |
-| **Size distributions** | Random only | **Uniform + Lognormal** (realistic) |
-| **Concurrency control** | Global only | **Per-operation** override |
-| **Prepare profiles** | Basic | **Documented patterns** with realistic distributions |
-| **Backend support** | S3 only | **5 backends** (S3, Azure, GCS, File, Direct I/O) |
-| **Remapping** | 1:1 only | **1:1, 1→N, N→1, N↔N** (regex) |
-| **Output format** | Text analysis | **TSV** (13 columns, machine-readable) |
-| **Memory usage** | High (replay) | **Constant** (streaming replay ~1.5 MB) |
-
-## 🌟 Previous Releases
-
-### v0.6.2 - s3dlio v0.9.5 Upgrade & Naming Cleanup
-- **s3dlio v0.9.5**: Minor performance improvements and bug fixes
-- **Comprehensive cleanup**: All io-bench references updated to sai3-bench
-- **Test fixes**: Streaming replay tests now properly documented (require --test-threads=1)
-- **RangeEngine**: Uses s3dlio defaults (custom config planned for future release)
-- **Documentation**: Updated branding, test configs, and usage examples
-
-### v0.5.9 - Output Clarity & Branding Consistency
-- **Enhanced metrics display**: Added mean latency to Results output
-- **Cleaner console output**: Removed duplicate histogram display
-- **Branding updates**: Consistent "sai3-bench" terminology throughout
-- **Documentation**: Updated CLI help examples and code comments
-
-### v0.5.4 - Storage Efficiency Testing
-- **Deduplication testing**: Configurable block-level duplication patterns
-- **Compression testing**: Adjustable data compressibility (zero-fill ratios)
-- **Size distributions**: Lognormal, uniform, and fixed distributions
-- **Per-operation concurrency**: Fine-grained worker pool control
-
-### v0.5.2 - Machine-Readable Results & Enhanced Metrics
-- **TSV export**: 13-column format for automated analysis
-- **Enhanced metrics**: Mean + median, size-bucketed histograms
-- **Performance validated**: 19.6k ops/s on file backend
-- **Default concurrency**: Increased to 32 workers
-
-### v0.5.0 - Advanced Replay Remapping
-- **1→N Fanout**: Distribute operations across multiple targets (round_robin, random, sticky_key)
-- **N→1 Consolidation**: Merge multiple sources to single target
-- **Regex Remapping**: Pattern-based URI transformation for complex migrations
-- **Streaming replay**: Constant ~1.5 MB memory via s3dlio-oplog integration
-
-### v0.4.3 - Prepare/Pre-population
-- **Prepare step**: Ensure objects exist before testing (Warp parity)
-- **Cleanup support**: Optional deletion of prepared objects after tests
-- **CLI flags**: `--prepare-only` and `--no-cleanup` for flexible workflows
-
-### v0.4.2 - Google Cloud Storage Support
-- **GCS backend**: Full integration with `gs://` and `gcs://` URI schemes
-- **Application Default Credentials**: Seamless gcloud CLI authentication
-- **Performance validated**: 9-11 MB/s for large objects, ~400-600ms latency
-
-### v0.4.1 - Streaming Replay
-- **Constant memory**: Stream replay with ~1.5 MB footprint (vs. full file in memory)
-- **Background decompression**: Efficient handling of zstd-compressed op-logs
-
-### v0.4.0 - Timing-Faithful Replay
-- **Microsecond precision**: Replay with ~10µs accuracy
-- **Backend retargeting**: Simple 1:1 URI remapping
-- **Speed control**: Adjustable replay speed (e.g., 2x, 0.5x)
-
-### v0.3.x - Enhanced UX
-- **Interactive progress bars**: Professional real-time visualization
-- **Time-based progress**: Smooth animated tracking with ETA
-- **Smart messages**: Dynamic context showing concurrency, sizes, rates
-
-### 🚀 Quick Start
+## 🚀 Quick Start
 
 ```bash
 # Install and build
 cargo build --release
 
 # Test local filesystem
-./target/release/sai3-bench health --uri "file:///tmp/test/"
-./target/release/sai3-bench put --uri "file:///tmp/test/data*.txt" --object-size 1024 --objects 100
+./target/release/sai3-bench util health --uri "file:///tmp/test/"
+./target/release/sai3-bench util put --uri "file:///tmp/test/data*.txt" --object-size 1024 --objects 100
 
-# Validate config file before running (parse check + test summary)
+# Validate config file before running
 ./target/release/sai3-bench run --config my-workload.yaml --dry-run
 
-# Capture workload with op-log
+# Run workload with automatic results directory
+./target/release/sai3-bench run --config my-workload.yaml
+
+# Capture workload with operation logging
 ./target/release/sai3-bench --op-log /tmp/workload.tsv.zst \
   run --config my-workload.yaml
 
-# Run workload with TSV export for machine-readable results
-./target/release/sai3-bench run --config my-workload.yaml \
-  --results-tsv /tmp/benchmark-results
-
 # Replay workload to different backend
 ./target/release/sai3-bench replay --op-log /tmp/workload.tsv.zst \
-  --target "s3://mybucket/prefix/" --speed 2.0
+  --target "az://test-storage/container/"
 
-# Advanced: Replay with 1→N fanout remapping
-./target/release/sai3-bench replay --op-log /tmp/workload.tsv.zst \
-  --remap fanout-config.yaml
+# Replay at higher speed for load testing
+./target/release/sai3-bench replay --op-log /tmp/workload.tsv.zst --speed 5.0
 
-# Test Azure Blob Storage (requires setup)
+# Test cloud storage (requires authentication)
 export AZURE_STORAGE_ACCOUNT="your-storage-account"
 export AZURE_STORAGE_ACCOUNT_KEY="your-account-key"
-./target/release/sai3-bench health --uri "az://your-storage-account/container/"
+./target/release/sai3-bench util health --uri "az://your-storage-account/container/"
 
-# Test Google Cloud Storage (requires gcloud auth)
 gcloud auth application-default login
-./target/release/sai3-bench health --uri "gs://my-bucket/prefix/"
+./target/release/sai3-bench util health --uri "gs://my-bucket/prefix/"
 ```
 
 ### 📊 Performance Characteristics
 
-- **File Backend**: 25k+ ops/s, sub-millisecond latencies, 19.6k ops/s with full metrics
+- **File Backend**: 25k+ ops/s, sub-millisecond latencies
 - **Direct I/O Backend**: 10+ MB/s throughput, ~100ms latencies  
 - **S3 Backend**: Network-dependent, validated with real buckets
 - **Azure Blob Storage**: 2-3 ops/s, ~700ms latencies (network dependent)
 - **GCS Backend**: 9-11 MB/s for large objects, ~400-600ms for small operations
-- **Cross-Backend Workloads**: Mixed protocol operations in single configuration
 
-### 🔧 Requirements
+## 🔬 Workload Replay
 
-- **Rust**: Stable toolchain (2024 edition)
-- **Protobuf**: `protoc` compiler for gRPC (distributed mode)
-- **Storage Credentials**: Backend-specific authentication (AWS, Azure, GCS)
-
-See the [Usage Guide](docs/USAGE.md) for detailed setup instructions.
-
-### 🎬 Workload Replay Examples
+Record actual production workloads and replay them with microsecond fidelity for realistic testing:
 
 ```bash
-# Capture a workload to op-log
-sai3-bench -v --op-log /tmp/production.tsv.zst run --config prod-workload.yaml
+# Step 1: Capture production workload (transparent logging)
+sai3-bench --op-log /tmp/production.tsv.zst run --config production.yaml
 
-# Replay with exact timing
-sai3-bench replay --op-log /tmp/production.tsv.zst
+# Step 2: Replay against test environment with exact timing
+sai3-bench replay --op-log /tmp/production.tsv.zst --target "az://test-storage/"
 
-# Replay to different backend (migration testing)
-sai3-bench replay --op-log /tmp/s3-workload.tsv.zst \
-  --target "az://newstorage/container/"
+# Step 3: Migration testing - replay S3 workload against GCS
+sai3-bench replay --op-log /tmp/s3-prod.tsv.zst --target "gs://migration-test/"
 
-# Replay at 10x speed for quick testing
-sai3-bench replay --op-log /tmp/workload.tsv.zst --speed 10.0
+# Step 4: Load testing - replay at higher speeds
+sai3-bench replay --op-log /tmp/prod.tsv.zst --speed 5.0
 
-# Advanced: 1→N fanout with round-robin strategy
+# Advanced: 1→N fanout remapping with strategy
 cat > fanout.yaml <<EOF
 rules:
   - match: {bucket: "source"}
@@ -571,66 +119,163 @@ rules:
       strategy: "round_robin"
 EOF
 sai3-bench replay --op-log /tmp/workload.tsv.zst --remap fanout.yaml
-
-# Replay with error tolerance
-sai3-bench replay --op-log /tmp/workload.tsv.zst --continue-on-error
 ```
 
-### 📈 TSV Export for Analysis
+**Real-World Applications**:
+- **Pre-Migration Validation**: Test new storage backend with exact production load
+- **Performance Regression Testing**: Detect changes using historical workload patterns
+- **Capacity Planning**: Model peak load behavior with recorded traffic spikes
+- **Cross-Cloud Comparison**: Run identical workloads across AWS, Azure, GCS
+- **Cost Analysis**: Measure actual vs. synthetic workload costs
+
+## 💾 Storage Efficiency Testing
+
+Test deduplication and compression with controlled data generation:
+
+```yaml
+prepare:
+  ensure_objects:
+    # Highly dedupable data (VM templates, OS images)
+    - base_uri: "s3://bucket/templates/"
+      count: 100
+      size_distribution:
+        type: fixed
+        size: 10485760  # 10 MB
+      fill: random      # ⚠️ RECOMMENDED for realistic testing
+      dedup_factor: 20  # 95% duplicate blocks
+      compress_factor: 2  # 2:1 compression ratio
+    
+    # Document storage (moderate compression)
+    - base_uri: "s3://bucket/documents/"
+      count: 5000
+      size_distribution:
+        type: lognormal
+        mean: 524288
+        std_dev: 262144
+      fill: random
+      dedup_factor: 3   # 67% unique blocks
+      compress_factor: 4  # 4:1 compression ratio
+    
+    # Media files (minimal compression)
+    - base_uri: "s3://bucket/media/"
+      count: 500
+      size_distribution:
+        type: uniform
+        min: 5242880
+        max: 52428800
+      fill: random
+      dedup_factor: 1   # 100% unique (no dedup)
+      compress_factor: 1  # Uncompressible
+```
+
+**Parameters Explained**:
+- `fill: random` - **RECOMMENDED** - Realistic data for storage testing (use `fill: zero` only for specific zero-data testing)
+- `dedup_factor`: 1 = all unique, 5 = 80% dedup, 10 = 90% dedup
+- `compress_factor`: 1 = uncompressible, 3 = 3:1 ratio, 5 = 5:1 ratio
+
+**Use Cases**:
+- Validate storage vendor dedup/compression claims
+- Predict space requirements for migrations
+- Model hot vs. cold data characteristics
+- Calculate true storage costs with efficiency features
+
+## 📐 Realistic Size Distributions
+
+**Lognormal Distribution** (recommended for realistic modeling):
+```yaml
+workload:
+  - op: put
+    path: "data/"
+    weight: 100
+    size_distribution:
+      type: lognormal
+      mean: 1048576      # Mean: 1 MB
+      std_dev: 524288    # Std dev: 512 KB
+      min: 1024          # Floor: 1 KB
+      max: 10485760      # Ceiling: 10 MB
+    fill: random
+```
+
+**Why lognormal?** Research shows object storage workloads naturally follow lognormal distributions - many small files (configs, thumbnails) and few large files (videos, backups). Far more realistic than uniform random distributions.
+
+Other supported distributions:
+- **Fixed**: Exact size for each object
+- **Uniform**: Evenly distributed between min and max
+
+## 🌐 Distributed Testing
+
+Run coordinated workloads across multiple agent nodes:
 
 ```bash
-# Run workload with machine-readable results export
-sai3-bench run --config workload.yaml --results-tsv /tmp/results
+# Start agents on multiple hosts
+sai3bench-agent --listen 0.0.0.0:7761  # On each host
 
-# Generated file: /tmp/results-results.tsv with 13 columns:
-# operation, size_bucket, bucket_idx, mean_us, p50_us, p90_us, p95_us, 
-# p99_us, max_us, avg_bytes, ops_per_sec, throughput_mibps, count
-
-# Parse with any TSV tool (awk, pandas, polars, etc.)
-awk -F'\t' 'NR>1 {print $1, $2, $4, $5, $12}' /tmp/results-results.tsv
-# Shows: operation, size_bucket, mean_us, p50_us, throughput_mibps
+# Run distributed workload from controller
+sai3bench-ctl --insecure \
+  --agents host1:7761,host2:7761,host3:7761 \
+  run --config workload.yaml --start-delay 2
 ```
 
-**Key Features:**
-- **Microsecond Precision**: ~10µs timing accuracy using absolute timeline scheduling
-- **Verbose Logging**: `-v` for operational info, `-vv` for detailed debug tracing
-- **Pattern Matching**: Glob patterns (`*`) and directory listings supported across backends
-- **Concurrent Execution**: Semaphore-controlled concurrency with configurable worker counts
+**Key Features**:
+- **Coordinated Start**: All agents begin simultaneously
+- **Smart Storage Detection**: Automatic shared vs. local storage handling
+- **Result Aggregation**: Per-agent and combined metrics with HDR histogram merging
+- **Automatic Results Collection**: Consolidated results directory with per-agent subdirectories
 
-### Technical Notes
+See [Distributed Testing Guide](docs/DISTRIBUTED_TESTING_GUIDE.md) for detailed examples.
 
-**v0.4.0 Release** - Added timing-faithful workload replay with microsecond-precision scheduling. All operations use ObjectStore trait abstraction via s3dlio library for unified multi-backend support (file://, direct://, s3://, az://). Production-ready with comprehensive testing and logging.
+## ⚙️ Advanced Features
 
-**Migration History** - Successfully migrated from direct AWS SDK calls to ObjectStore trait. Multi-backend URIs fully operational with comprehensive logging and performance validation.
+### Per-Operation Concurrency
+Fine-grained control over worker pools:
+```yaml
+concurrency: 32  # Global default
+
+workload:
+  - op: get
+    path: "data/*"
+    weight: 70
+    concurrency: 64  # More GET workers
+  
+  - op: put
+    path: "uploads/"
+    weight: 30
+    size_distribution: {type: fixed, size: 1048576}
+    concurrency: 8   # Fewer PUT workers
+```
+
+### Config Validation
+Verify YAML syntax and configuration before execution:
+```bash
+sai3-bench run --config my-workload.yaml --dry-run
+```
+
+Displays:
+- Test configuration (duration, concurrency, backend)
+- Prepare phase details (if configured)
+- Workload operations with percentages
+- Any configuration errors with clear messages
+
+### Operation Logging
+Record all operations for replay or analysis:
+```bash
+# Always zstd compressed
+sai3-bench --op-log /tmp/operations.tsv.zst run --config workload.yaml
+
+# Decompress to view
+zstd -d /tmp/operations.tsv.zst -o /tmp/operations.tsv
+```
 
 ## 🛠️ Development
 
-### Running Tests
+### Requirements
+- **Rust**: Stable toolchain (2024 edition)
+- **Protobuf**: `protoc` compiler for gRPC (distributed mode)
+- **Storage Credentials**: Backend-specific authentication (AWS, Azure, GCS)
 
-Most tests can be run in parallel:
-```bash
-cargo test
-```
-
-However, `streaming_replay_tests` must run sequentially due to shared state:
-```bash
-cargo test --test streaming_replay_tests -- --test-threads=1
-```
-
-Or run all tests properly:
-```bash
-# Unit tests
-cargo test --lib
-
-# Integration tests (run individually)
-cargo test --test utils
-cargo test --test gcs_tests  
-cargo test --test grpc_integration
-cargo test --test streaming_replay_tests -- --test-threads=1
-```
+See [Cloud Storage Setup](docs/CLOUD_STORAGE_SETUP.md) for authentication details.
 
 ### Building
-
 ```bash
 # Development build
 cargo build
@@ -639,7 +284,15 @@ cargo build
 cargo build --release
 ```
 
+### Running Tests
+```bash
+# Most tests can run in parallel
+cargo test
+
+# Streaming replay tests must run sequentially
+cargo test --test streaming_replay_tests -- --test-threads=1
+```
+
 ## 📄 License
 
 GPL-3.0 License - See [LICENSE](LICENSE) for details.
-

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable changes to sai3-bench will be documented in this file.
 
+## [0.6.6] - 2025-10-11
+
+### ⚠️ BREAKING CHANGE: Command Structure Restructured
+
+**Utility commands now nested under `util` subcommand** to emphasize core workload execution features (run/replay). This change improves tool clarity and aligns with its primary purpose as a benchmarking suite.
+
+#### Breaking Changes
+- **All utility commands require `util` prefix**:
+  - ❌ OLD: `sai3-bench health --uri "s3://bucket/"`
+  - ✅ NEW: `sai3-bench util health --uri "s3://bucket/"`
+  
+- **Affected commands**: health, list, stat, get, put, delete
+- **Unaffected commands**: run, replay (these are now prominently featured)
+- **Error message**: If you try to use old syntax (e.g., `sai3-bench health`), you'll get "unrecognized subcommand" error. Simply add `util` before the command name.
+
+#### Command Structure
+```
+OLD Structure:
+  sai3-bench {health|list|stat|get|delete|put|run|replay}
+
+NEW Structure (v0.6.6):
+  sai3-bench {run|replay|util}
+    util subcommand: {health|list|stat|get|put|delete}
+```
+
+#### Benefits
+1. **Core features prominently displayed**: `run` and `replay` now appear first
+2. **Cleaner help output**: Only 3 top-level commands instead of 8
+3. **Clear tool purpose**: Emphasizes benchmarking/workload execution
+4. **Better organization**: Utility operations clearly separated from core functionality
+
+#### Migration Guide
+Update all utility command invocations:
+```bash
+# Health checks
+sai3-bench util health --uri "file:///tmp/test/"
+sai3-bench util health --uri "s3://bucket/"
+sai3-bench util health --uri "az://account/container/"
+sai3-bench util health --uri "gs://bucket/"
+
+# List operations
+sai3-bench util list --uri "s3://bucket/prefix/"
+
+# Get/Put/Delete operations
+sai3-bench util get --uri "s3://bucket/*" --jobs 8
+sai3-bench util put --uri "file:///tmp/" --object-size 1024 --objects 100
+sai3-bench util delete --uri "s3://bucket/prefix/*"
+```
+
+#### Note on Utility Commands
+For comprehensive storage CLI operations, consider using `s3-cli` from the [s3dlio package](https://github.com/russfellows/s3dlio). The utility commands in sai3-bench are provided as convenience helpers for quick testing and validation.
+
+---
+
 ## [0.6.5] - 2025-10-11
 
 ### 🔍 Configuration Validation & Documentation Enhancements

--- a/docs/CLOUD_STORAGE_SETUP.md
+++ b/docs/CLOUD_STORAGE_SETUP.md
@@ -59,12 +59,12 @@ s3://my-benchmark-bucket/test-data/object.dat
 
 #### Health Check
 ```bash
-sai3-bench health --uri "s3://my-benchmark-bucket/"
+sai3-bench util health --uri "s3://my-benchmark-bucket/"
 ```
 
 #### List Objects
 ```bash
-sai3-bench list --uri "s3://my-benchmark-bucket/test-data/"
+sai3-bench util list --uri "s3://my-benchmark-bucket/test-data/"
 ```
 
 #### Upload Objects
@@ -124,7 +124,7 @@ export AWS_ENDPOINT_URL="https://minio.example.com"
 export AWS_ACCESS_KEY_ID="minioadmin"
 export AWS_SECRET_ACCESS_KEY="minioadmin"
 
-sai3-bench health --uri "s3://my-bucket/"
+sai3-bench util health --uri "s3://my-bucket/"
 ```
 
 ### Performance Characteristics
@@ -200,12 +200,12 @@ az://mycontainer/test-data/
 export AZURE_STORAGE_ACCOUNT="mystorageaccount"
 export AZURE_STORAGE_ACCOUNT_KEY="$(az storage account keys list --account-name mystorageaccount --query [0].value -o tsv)"
 
-sai3-bench health --uri "az://mystorageaccount/mycontainer/"
+sai3-bench util health --uri "az://mystorageaccount/mycontainer/"
 ```
 
 #### List Objects
 ```bash
-sai3-bench list --uri "az://mystorageaccount/mycontainer/test-data/"
+sai3-bench util list --uri "az://mystorageaccount/mycontainer/test-data/"
 ```
 
 #### Upload Objects
@@ -320,12 +320,12 @@ gcs://my-gcs-bucket/test-data/
 # Ensure credentials are set
 export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json"
 
-sai3-bench health --uri "gs://my-gcs-bucket/"
+sai3-bench util health --uri "gs://my-gcs-bucket/"
 ```
 
 #### List Objects
 ```bash
-sai3-bench list --uri "gs://my-gcs-bucket/test-data/"
+sai3-bench util list --uri "gs://my-gcs-bucket/test-data/"
 ```
 
 #### Upload Objects

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 - **[CLOUD_STORAGE_SETUP.md](CLOUD_STORAGE_SETUP.md)** - S3, Azure, and GCS authentication guides
 
 ### Reference Documentation
-- **[CHANGELOG.md](CHANGELOG.md)** - Complete version history (v0.1.0 → v0.6.5)
+- **[CHANGELOG.md](CHANGELOG.md)** - Complete version history (v0.1.0 → v0.6.6)
 - **[CONFIG_SYNTAX.md](CONFIG_SYNTAX.md)** - YAML configuration file reference
 - **[DATA_GENERATION.md](DATA_GENERATION.md)** - Data generation patterns and storage efficiency testing
 

--- a/tests/configs/README.md
+++ b/tests/configs/README.md
@@ -202,7 +202,7 @@ prepare:
 ### "No URIs found for pattern"
 - Ensure objects exist at the path
 - Check glob pattern syntax (use `*` for matching)
-- Verify backend connectivity with `sai3-bench health --uri <uri>`
+- Verify backend connectivity with `sai3-bench util health --uri <uri>`
 
 ### "Failed to parse config"
 - YAML indentation must be consistent (use spaces, not tabs)


### PR DESCRIPTION
BREAKING CHANGE: All utility commands now require 'util' prefix

- Restructured Commands enum: Run and Replay now prominently featured first
- Created UtilCommands nested subcommand for: health, list, stat, get, put, delete
- Updated all documentation with new command syntax
- Updated version to 0.6.6 in Cargo.toml
- Added comprehensive CHANGELOG entry with migration guide

Old syntax: sai3-bench health --uri 's3://bucket/'
New syntax: sai3-bench util health --uri 's3://bucket/'

Benefits:
- Core features (run/replay) prominently displayed
- Cleaner help output (3 top-level commands vs 8)
- Clear distinction between workload execution and utility helpers
- Aligns with tool's primary purpose as benchmarking suite

Files updated:
- src/main.rs: Command enum restructure + match statement updates
- README.md: Version badge, latest release notes, all examples
- docs/CHANGELOG.md: v0.6.6 release notes with migration guide
- docs/CLOUD_STORAGE_SETUP.md: All health/list command examples
- docs/README.md: Version reference
- tests/configs/README.md: Health command example