### PR TITLE
v0.8.8: Logging improvements and agent timeout fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4136,7 +4136,7 @@ dependencies = [
 
 [[package]]
 name = "sai3-bench"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sai3-bench"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2021"
 build   = "build.rs"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sai3-bench: Multi-Protocol I/O Benchmarking Suite
 
-[![Version](https://img.shields.io/badge/version-0.8.7-blue.svg)](https://github.com/russfellows/sai3-bench/releases)
+[![Version](https://img.shields.io/badge/version-0.8.8-blue.svg)](https://github.com/russfellows/sai3-bench/releases)
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](https://github.com/russfellows/sai3-bench)
 [![Tests](https://img.shields.io/badge/tests-170%20passing-success.svg)](https://github.com/russfellows/sai3-bench)
 [![License](https://img.shields.io/badge/license-GPL--3.0-blue.svg)](LICENSE)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,36 @@ All notable changes to sai3-bench are documented in this file.
 
 ---
 
+## [0.8.8] - 2025-12-02
+
+### Changed
+
+- **Logging verbosity improvements**
+  - Per-I/O operation logs (GET/PUT/LIST/STAT/DELETE starting/completing) moved from DEBUG to TRACE level
+  - Status and coordination messages remain at DEBUG level
+  - `-vv` now shows operational information without flooding with per-operation details
+  - `-vvv` enables full per-I/O transaction logging for debugging
+
+- **s3dlio logging level offset** - All three binaries now properly offset s3dlio logging:
+  - `-v`: sai3-bench=info, s3dlio=warn
+  - `-vv`: sai3-bench=debug, s3dlio=info
+  - `-vvv`: sai3-bench=trace, s3dlio=debug
+  - Previously only `sai3-bench` CLI had this; now `sai3bench-agent` and `sai3bench-ctl` also include it
+
+### Fixed
+
+- **Agent idle timeout removed** - Agents now run indefinitely as long-lived services
+  - Removed 30-second IDLE timeout that caused agents to fail after inactivity
+  - READY timeout (60s) retained: auto-resets to IDLE if controller fails to send START
+  - Agents survive 5+ minutes idle and accept new workloads without restart
+
+### Documentation
+
+- Updated `.github/copilot-instructions.md` with v0.8.8 features
+- Clarified logging level behavior and s3dlio integration
+
+---
+
 ## [0.8.7] - 2025-11-26
 
 ### Added

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -152,16 +152,12 @@ pub const DEFAULT_AGENT_HEARTBEAT_SECS: u64 = 1;
 // Bidirectional Streaming Timeouts (v0.8.4+)
 // =============================================================================
 
-/// Agent IDLE state timeout (seconds)
-/// Agent must receive initial START command within this time
-pub const AGENT_IDLE_TIMEOUT_SECS: u64 = 30;
-
-/// Agent prepare phase timeout (seconds)
-/// Prepare phase (config validation + file creation) must complete within this time
-pub const AGENT_PREPARE_TIMEOUT_SECS: u64 = 30;
+// NOTE: IDLE state has NO timeout - agents wait indefinitely for controllers.
+// This allows agents to run as long-lived services that accept connections on demand.
 
 /// Agent READY state timeout (seconds)
 /// Agent must receive coordinated START command within this time after becoming READY
+/// If exceeded, agent returns to IDLE state and is ready for new connections
 pub const AGENT_READY_TIMEOUT_SECS: u64 = 60;
 
 /// Controller connection timeout (seconds)

--- a/src/metadata_prefetch.rs
+++ b/src/metadata_prefetch.rs
@@ -5,7 +5,7 @@
 // of I/O operations.
 
 use tokio::sync::mpsc;
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 /// Metadata information for an object
 #[derive(Debug, Clone)]
@@ -148,7 +148,7 @@ async fn fetch_metadata_for_uri(uri: &str) -> ObjectMetadata {
         // Fetch metadata using tokio's fs (async)
         match tokio::fs::metadata(path_str).await {
             Ok(meta) => {
-                debug!("Prefetched metadata for {}: {} bytes", uri, meta.len());
+                trace!("Prefetched metadata for {}: {} bytes", uri, meta.len());
                 Some(meta.len())
             }
             Err(e) => {


### PR DESCRIPTION
# Pull Request: v0.8.8 Logging Improvements and Agent Timeout Fix

## Summary

This PR improves logging verbosity control and fixes a critical agent timeout issue that prevented agents from running as long-lived services.

## Changes

### 🔧 Logging Verbosity Improvements

**Per-I/O operation logs moved from DEBUG to TRACE level**

Previously, using `-vv` (DEBUG level) would flood the console with every single I/O operation:
```
DEBUG GET operation starting for URI: file:///mnt/test/data/file001.dat
DEBUG GET operation completed successfully for URI: file:///mnt/test/data/file001.dat, 4096 bytes
DEBUG GET operation starting for URI: file:///mnt/test/data/file002.dat
...
```

Now, `-vv` shows operational status without per-operation flooding. Use `-vvv` for full transaction logging.

| Verbosity | sai3-bench Level | What You See |
|-----------|------------------|--------------|
| (none) | warn | Only warnings and errors |
| `-v` | info | Progress, summaries, key events |
| `-vv` | debug | Status messages, configuration, error details |
| `-vvv` | trace | Full per-I/O transaction logs |

**Files changed:**
- `src/workload.rs` - All GET/PUT/LIST/STAT/DELETE/MKDIR/RMDIR operations
- `src/metadata_prefetch.rs` - Metadata prefetch logging

### 🔧 s3dlio Logging Level Offset

All three binaries now properly offset s3dlio library logging by one level:

| Verbosity | App Level | s3dlio Level |
|-----------|-----------|--------------|
| `-v` | info | warn |
| `-vv` | debug | info |
| `-vvv` | trace | debug |

This prevents s3dlio internal logs from overwhelming application-level logging.

**Files changed:**
- `src/bin/agent.rs` - Added s3dlio level offset (was missing)
- `src/bin/controller.rs` - Added s3dlio level offset (was missing)
- `src/main.rs` - Already had correct implementation (unchanged)

### 🐛 Agent Idle Timeout Fix

**Problem:** Agents had a 30-second IDLE timeout that caused them to fail after inactivity, preventing use as long-lived services.

**Solution:** Removed IDLE timeout entirely. Agents now wait indefinitely for controllers.

- READY timeout (60s) retained: auto-resets to IDLE if controller fails to send START
- Tested: agents survive 5+ minutes idle and accept new workloads without restart

**Files changed:**
- `src/constants.rs` - Removed `AGENT_IDLE_TIMEOUT_SECS` and `AGENT_PREPARE_TIMEOUT_SECS`
- `src/bin/agent.rs` - Updated timeout monitoring logic

## Testing

- ✅ `cargo build --release` - No warnings
- ✅ Started 2 agents, waited 5+ minutes, ran workload - Success
- ✅ Verified `-vv` no longer floods with per-I/O logs
- ✅ Verified `-vvv` shows full transaction details

## Related Issues

- Closes #46 (Op-Log Support for Distributed Agents) - **Already implemented**, issue can be closed
  - Agent `--op-log` CLI flag exists
  - Appends agent-ID suffix to filename
  - Priority: config YAML > CLI flag > None

## Backward Compatibility

✅ Fully backward compatible
- No breaking changes to CLI or config format
- Existing scripts continue to work
- Only logging output changes (less verbose by default)