### PR TITLE
v0.8.14: Fix state machine race, cleanup bugs, add directory cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "sai3-bench"
-version = "0.8.13"
+version = "0.8.14"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sai3-bench"
-version = "0.8.13"
+version = "0.8.14"
 edition = "2021"
 build   = "build.rs"
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # sai3-bench: Multi-Protocol I/O Benchmarking Suite
 
-[![Version](https://img.shields.io/badge/version-0.8.13-blue.svg)](https://github.com/russfellows/sai3-bench/releases)
+[![Version](https://img.shields.io/badge/version-0.8.14-blue.svg)](https://github.com/russfellows/sai3-bench/releases)
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](https://github.com/russfellows/sai3-bench)
-[![Tests](https://img.shields.io/badge/tests-240%20passing-success.svg)](https://github.com/russfellows/sai3-bench)
+[![Tests](https://img.shields.io/badge/tests-269%20passing-success.svg)](https://github.com/russfellows/sai3-bench)
 [![License](https://img.shields.io/badge/license-GPL--3.0-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.90%2B-green.svg)](https://www.rust-lang.org/)
 

--- a/proto/iobench.proto
+++ b/proto/iobench.proto
@@ -174,6 +174,7 @@ message LiveStats {
     STAGE_PREPARE = 1;    // Creating objects before workload
     STAGE_WORKLOAD = 2;   // Main benchmark execution (GET/PUT/etc.)
     STAGE_CLEANUP = 3;    // Deleting objects after workload
+    STAGE_LISTING = 4;    // v0.8.14: Scanning existing objects before prepare
     STAGE_CUSTOM = 10;    // User-defined custom stage (use stage_name)
   }
   WorkloadStage current_stage = 30;      // Current execution stage
@@ -181,6 +182,9 @@ message LiveStats {
   uint64 stage_progress_current = 32;    // Progress within stage (objects created/deleted, etc.)
   uint64 stage_progress_total = 33;      // Total items for this stage (0 = time-based like workload)
   double stage_elapsed_s = 34;           // Seconds since this stage started
+  
+  // v0.8.14: Agent concurrency for total thread count display
+  uint32 concurrency = 35;               // Number of concurrent workers on this agent
 }
 
 service Agent {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -74,6 +74,22 @@ pub const DEFAULT_PREPARE_MAX_ERRORS: u64 = 100;
 pub const DEFAULT_PREPARE_MAX_CONSECUTIVE_ERRORS: u64 = 10;
 
 // =============================================================================
+// Listing Phase Error Handling (v0.8.14)
+// =============================================================================
+
+/// Maximum total errors during listing phase before aborting
+/// LIST operations can fail on transient network issues
+pub const DEFAULT_LISTING_MAX_ERRORS: u64 = 50;
+
+/// Maximum consecutive errors during listing before aborting
+/// Indicates backend is completely unreachable
+pub const DEFAULT_LISTING_MAX_CONSECUTIVE_ERRORS: u64 = 5;
+
+/// Progress update interval for listing (number of files between updates)
+/// Balances visibility with performance overhead
+pub const LISTING_PROGRESS_INTERVAL: u64 = 1000;
+
+// =============================================================================
 // Workload Execution Defaults
 // =============================================================================
 

--- a/src/pb/iobench.rs
+++ b/src/pb/iobench.rs
@@ -273,6 +273,11 @@ pub struct LiveStats {
     /// Seconds since this stage started
     #[prost(double, tag = "34")]
     pub stage_elapsed_s: f64,
+    /// v0.8.14: Agent concurrency for total thread count display
+    ///
+    /// Number of concurrent workers on this agent
+    #[prost(uint32, tag = "35")]
+    pub concurrency: u32,
 }
 /// Nested message and enum types in `LiveStats`.
 pub mod live_stats {
@@ -358,6 +363,8 @@ pub mod live_stats {
         StageWorkload = 2,
         /// Deleting objects after workload
         StageCleanup = 3,
+        /// v0.8.14: Scanning existing objects before prepare
+        StageListing = 4,
         /// User-defined custom stage (use stage_name)
         StageCustom = 10,
     }
@@ -372,6 +379,7 @@ pub mod live_stats {
                 Self::StagePrepare => "STAGE_PREPARE",
                 Self::StageWorkload => "STAGE_WORKLOAD",
                 Self::StageCleanup => "STAGE_CLEANUP",
+                Self::StageListing => "STAGE_LISTING",
                 Self::StageCustom => "STAGE_CUSTOM",
             }
         }
@@ -382,6 +390,7 @@ pub mod live_stats {
                 "STAGE_PREPARE" => Some(Self::StagePrepare),
                 "STAGE_WORKLOAD" => Some(Self::StageWorkload),
                 "STAGE_CLEANUP" => Some(Self::StageCleanup),
+                "STAGE_LISTING" => Some(Self::StageListing),
                 "STAGE_CUSTOM" => Some(Self::StageCustom),
                 _ => None,
             }


### PR DESCRIPTION
# Pull Request: v0.8.14 - Distributed Listing Stage & Critical Bug Fixes

## Overview

This PR introduces distributed listing with real-time progress tracking, fixes critical agent state machine and cleanup bugs, and adds comprehensive directory structure cleanup for tree mode.

## Breaking Changes

None - all changes are backward compatible.

## Major Bug Fixes

### 1. Agent State Machine Race Condition

**Problem**: After successful workload completion, agents showed ERROR state with spurious log messages:
- `ERROR: Invalid state transition: Idle → Idle`
- `WARN: Abnormal disconnect during Running state`

**Root Cause**: Race condition between stats writer and control reader tasks:
1. Stats writer sends COMPLETED message, waits 3 seconds for flush
2. Controller receives COMPLETED, closes stream (normal disconnect)
3. Control reader detects disconnect while agent state is still "Running"
4. Control reader treats this as abnormal and transitions to Idle
5. Stats writer wakes up and tries Idle→Idle transition → ERROR

**Fix**: 
- Added `completion_sent: Arc<Mutex<bool>>` flag to coordinate the two tasks
- Control reader checks flag: if `completion_sent && state==Running` → normal disconnect
- Same-state transitions (`Idle→Idle`, `Failed→Failed`) now valid no-ops

### 2. Distributed Cleanup Double-Filtering Bug (Major Performance Fix)

**Problem**: Cleanup running at ~900 ops/s instead of expected ~20,000 ops/s with 8 agents.

**Root Cause**: Double-filtering in cleanup phase:
- `prepare_objects()` returns only THIS agent's prepared objects (correctly filtered)
- `cleanup_prepared_objects()` re-filtered by `list_index % num_agents == agent_id`
- Result: Each agent only deleted 1/N² of their objects instead of 1/N

**Fix**:
- Removed modulo filtering from `cleanup_prepared_objects()`
- Caller is now responsible for passing the correct subset
- Added filtering to `list_existing_objects()` for cleanup-only mode

### 3. Empty Directories Remaining After Cleanup

**Problem**: GCS retains folder marker objects after file deletion, leaving empty directory structure.

**Fix**: Agent 0 now performs directory structure cleanup after file deletion:
- Uses tree manifest to determine tree root URI
- Lists remaining objects under tree prefix
- Deletes folder markers, `.keep` files, and other placeholders

## New Features

### Distributed Listing Stage with Progress

- New `STAGE_LISTING = 4` in proto and `WorkloadStage::Listing` enum
- Real-time progress updates every 1000 files during listing operations
- Each agent lists only their assigned directories (distributed by tree manifest)
- Uses streaming `list_stream()` API instead of blocking `list()`
- Progress shows files found and rate (files/second)

### Robust Listing Error Handling

- New `ListingErrorTracker` with configurable thresholds
- `DEFAULT_LISTING_MAX_ERRORS` = 50 total errors before abort
- `DEFAULT_LISTING_MAX_CONSECUTIVE_ERRORS` = 5 consecutive errors before abort
- Consecutive counter resets on success (handles transient network issues)
- Error messages collected for debugging (first 20 errors)

### Total Threads Display in Controller

- Shows aggregate concurrency across all agents during all stages
- New `concurrency` field in proto `LiveStats` message (field 35)
- Display format: "8 of 8 Agents (512 threads)" when concurrency > 0
- Visible during prepare, workload, cleanup, and listing stages

## Files Changed

| File | Changes |
|------|---------|
| `Cargo.toml` | Version bump to 0.8.14 |
| `proto/iobench.proto` | Added concurrency field (35) to LiveStats |
| `src/bin/agent.rs` | State machine race fix, completion_sent flag, 17 new tests |
| `src/bin/controller.rs` | Total threads aggregation and display |
| `src/cleanup.rs` | Removed double-filter, added directory cleanup |
| `src/constants.rs` | New listing error thresholds |
| `src/live_stats.rs` | Concurrency tracking |
| `src/prepare.rs` | Distributed listing with progress, ListingErrorTracker |
| `src/pb/iobench.rs` | Generated proto code |
| `docs/CHANGELOG.md` | Comprehensive documentation of changes |
| `README.md` | Updated test badge (269 tests) |

## Testing

- **269 tests passing** (up from 252)
- **17 new agent state machine tests** covering:
  - State transition validation (6 tests)
  - Async `transition_to()` behavior (4 tests)
  - Completion sent flag (4 tests)
  - Race condition scenarios (3 tests)
- **12 new ListingErrorTracker tests** covering:
  - Threshold behavior
  - Consecutive error handling
  - Thread safety
  - Error message collection

## Performance Impact

- **Cleanup**: Now scales linearly with number of agents (was O(N²) before)
- **Listing**: Progress visible during long listing operations (can take 1+ hour)
- **State machine**: No functional change, just eliminates spurious error logs

## Deployment Notes

- No configuration changes required
- Backward compatible with existing YAML configs
- Agents and controller should be upgraded together for new features

## Reviewers

Please pay particular attention to:
1. The `completion_sent` flag coordination in `src/bin/agent.rs`
2. The modulo filtering removal in `src/cleanup.rs`
3. The directory cleanup logic for tree mode